### PR TITLE
radio_buttons helper

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,6 +69,14 @@ See description above...
 = f.collection_radio_buttons :primary_category_id, Category.all, :id, :name
 ```
 
+### radio_buttons
+
+```haml
+= f.radio_buttons :published, { "Published" => true, "Unpublished" => false }
+```
+
+Ruby 1.8 doesn't guarantee hashes are ordered. If you care, pass in nested arrays or `ActiveSupport::OrderedHash`.
+
 Uneditable Input
 ----------------
 Bootstrap Forms adds another helper method that generates the necessary markup for uneditable inputs:

--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -23,7 +23,7 @@ module BootstrapForms
       fields_for(record_name, record_object, options, &block)
     end
 
-    %w(collection_select select email_field file_field number_field password_field phone_field radio_button range_field search_field telephone_field text_area text_field url_field).each do |method_name|
+    %w(collection_select select email_field file_field number_field password_field phone_field range_field search_field telephone_field text_area text_field url_field).each do |method_name|
       define_method(method_name) do |name, *args|
         @name = name
         @options = args.extract_options!
@@ -47,6 +47,21 @@ module BootstrapForms
           label(@name, :class => [ 'checkbox', required_class ].compact.join(' ')) do
             extras { super(name, *(@args << @options)) + object.class.human_attribute_name(name) }
           end
+        end
+      end
+    end
+
+    def radio_buttons(name, values={}, opts={})
+      @name = name
+      @options = opts
+
+      control_group_div do
+        label_field + input_div do
+          values.map do |text, value|
+            label("#{@name}_#{value}", :class => [ 'radio', required_class ].compact.join(' ')) do
+              extras { radio_button(name, value, @options) + text }
+            end
+          end.join.html_safe
         end
       end
     end


### PR DESCRIPTION
`f.collection_radio_buttons` wasn't a good fit when it's not related objects but instead attribute values.

`collection_radio_buttons` could be refactored to use my method, probably something like:

```
radio_buttons(attribute, records.map { |r| [ r.send(record_name), r.send(record_id) ] }, opts)
```
