### PR TITLE
fix collection_radio_buttons elem name

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -91,7 +91,7 @@ module BootstrapForms
           content_tag(:div, :class => 'controls') do
             records.collect do |record|
               element_id = "#{object_name}_#{attribute}_#{record.send(record_id)}"
-              radiobutton = radio_button_tag("#{object_name}[#{attribute}][]", record.send(record_id), object.send(attribute) == record.send(record_id), @field_options.merge({:id => element_id}))
+              radiobutton = radio_button_tag("#{object_name}[#{attribute}]", record.send(record_id), object.send(attribute) == record.send(record_id), @field_options.merge({:id => element_id}))
 
               content_tag(:label, :class => ['radio', ('inline' if @field_options[:inline])].compact.join(' ')) do
                 radiobutton + content_tag(:span, record.send(record_name))


### PR DESCRIPTION
Since we're creating radio buttons, the element name should not end
with '[]' because that will cause Rails and other frameworks to parse
that value into an array eventhough the browser will only let the user
select one option.
