### PR TITLE
Create bootstrap_fields_for

### DIFF
--- a/lib/bootstrap_forms/initializer.rb
+++ b/lib/bootstrap_forms/initializer.rb
@@ -9,6 +9,11 @@ module ActionView
           f.error_messages.html_safe + capture(f, &block).html_safe
         end
       end
+      
+      def bootstrap_fields_for(record, options = {}, &block)
+        options[:builder] = BootstrapForms::FormBuilder
+        fields_for(record, nil, options, &block)
+      end
     end
   end
 end


### PR DESCRIPTION
This method returns a bootstrap_forms form builder for fields of an associated entity.
