### PR TITLE
append and prepend errors and no-label option

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -40,8 +40,12 @@ module BootstrapForms
 
       control_group_div do
         input_div do
-          label(@name, :class => [ 'checkbox', required_class ].compact.join(' ')) do
+          if @field_options[:label] == ""
             extras { super(name, *(@args << @field_options)) + (@field_options[:label].blank? ? human_attribute_name : @field_options[:label])}
+          else
+            label(@name, :class => [ 'checkbox', required_class ].compact.join(' ')) do
+              extras { super(name, *(@args << @field_options)) + (@field_options[:label].blank? ? human_attribute_name : @field_options[:label])}
+            end
           end
         end
       end
@@ -54,8 +58,12 @@ module BootstrapForms
       control_group_div do
         label_field + input_div do
           values.map do |text, value|
-            label("#{@name}_#{value}", :class => [ 'radio', required_class ].compact.join(' ')) do
+            if @field_options[:label] == ""
               extras { radio_button(name, value, @options) + text }
+            else
+              label("#{@name}_#{value}", :class => [ 'radio', required_class ].compact.join(' ')) do
+                extras { radio_button(name, value, @options) + text }
+              end
             end
           end.join.html_safe
         end

--- a/lib/bootstrap_forms/helpers/wrappers.rb
+++ b/lib/bootstrap_forms/helpers/wrappers.rb
@@ -48,10 +48,14 @@ module BootstrapForms
       end
 
       def label_field(&block)
-        if respond_to?(:object)
-          label(@name, block_given? ? block : @field_options[:label], :class => ['control-label', required_class].compact.join(' '))
+        if @field_options[:label] == ""
+          return "".html_safe
         else
-          label_tag(@name, block_given? ? block : @field_options[:label], :class => ['control-label', required_class].compact.join(' '))
+          if respond_to?(:object)
+             label(@name, block_given? ? block : @field_options[:label], :class => ['control-label', required_class].compact.join(' '))
+           else
+             label_tag(@name, block_given? ? block : @field_options[:label], :class => ['control-label', required_class].compact.join(' '))
+           end
         end
       end
 

--- a/lib/bootstrap_forms/helpers/wrappers.rb
+++ b/lib/bootstrap_forms/helpers/wrappers.rb
@@ -37,8 +37,9 @@ module BootstrapForms
       def input_div(&block)
         content_tag(:div, :class => 'controls') do
           if @field_options[:append] || @field_options[:prepend]
-            klass = 'input-prepend' if @field_options[:prepend]
-            klass = 'input-append' if @field_options[:append]
+            klass = [""]
+            klass << 'input-prepend' if @field_options[:prepend]
+            klass << 'input-append' if @field_options[:append]
             content_tag(:div, :class => klass, &block)
           else
             yield if block_given?


### PR DESCRIPTION
removed error when using 'input-append' and 'input-prepend' at the same time. 
added the possibility to pass 'label: ""' as option in check boxes, radio buttons and inputs to remove labels from the outputted html. useful when it's necessary to hide jquery-edited hidden inputs(for instance, you can now hide a check box, using a toggle-button as label to toggle its state).
