### PR TITLE
setting @options to opts overwrites options of form builder

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -53,16 +53,15 @@ module BootstrapForms
 
     def radio_buttons(name, values = {}, opts = {})
       @name = name
-      @options = opts
       @field_options = opts
       control_group_div do
         label_field + input_div do
           values.map do |text, value|
             if @field_options[:label] == '' || @field_options[:label] == false
-              extras { radio_button(name, value, @options) + text }
+              extras { radio_button(name, value, @field_options) + text }
             else
               label("#{@name}_#{value}", :class => [ 'radio', required_class ].compact.join(' ')) do
-                extras { radio_button(name, value, @options) + text }
+                extras { radio_button(name, value, @field_options) + text }
               end
             end
           end.join.html_safe


### PR DESCRIPTION
setting `@options` to opts overwrites options of form builder and all form fields start using options of `radio_buttons`. Just using `@field_options` for this seems to work fine.
