### PR TITLE
Allow custom fields by extending the FormBuilder

### DIFF
--- a/lib/bootstrap_forms.rb
+++ b/lib/bootstrap_forms.rb
@@ -6,4 +6,6 @@ module BootstrapForms
 
   autoload :FormBuilder
   autoload :Helpers
+  mattr_accessor(:default_form_builder)
+  self.default_form_builder = BootstrapForms::FormBuilder
 end

--- a/lib/bootstrap_forms/helpers/form_helper.rb
+++ b/lib/bootstrap_forms/helpers/form_helper.rb
@@ -2,7 +2,7 @@ module BootstrapForms
   module Helpers
     module FormHelper
       def bootstrap_form_for(record, options = {}, &block)
-        options[:builder] = BootstrapForms::FormBuilder
+        options[:builder] = options[:builder] || BootstrapForms.default_form_builder
         form_for(record, options) do |f|
           if f.object.respond_to?(:errors)
             f.error_messages.html_safe + capture(f, &block).html_safe
@@ -13,7 +13,7 @@ module BootstrapForms
       end
 
       def bootstrap_fields_for(record, options = {}, &block)
-        options[:builder] = BootstrapForms::FormBuilder
+        options[:builder] = options[:builder] || BootstrapForms.default_form_builder
         fields_for(record, nil, options, &block)
       end
     end

--- a/spec/dummy/app/helpers/my_custom_form_builder.rb
+++ b/spec/dummy/app/helpers/my_custom_form_builder.rb
@@ -1,0 +1,5 @@
+class MyCustomFormBuilder < ActionView::Helpers::FormBuilder
+	def error_messages
+		'' # return empty string
+	end
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -2,6 +2,8 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
+require 'bundler'
+Bundler.setup
 Bundler.require
 require "bootstrap_forms"
 

--- a/spec/lib/bootstrap_forms/bootstrap_form_for_spec.rb
+++ b/spec/lib/bootstrap_forms/bootstrap_form_for_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe "bootstrap_form_for" do
+	describe "default_form_builder" do
+		it "should be accessible" do
+			BootstrapForms.should respond_to(:default_form_builder)
+		end
+
+		it "should be the BootstrapForms form_builder by default" do
+			BootstrapForms.default_form_builder.should == BootstrapForms::FormBuilder
+		end
+
+		context "when set to something else" do
+			before do
+				BootstrapForms.default_form_builder = MyCustomFormBuilder
+			end
+
+			it "should be that other thing" do
+				BootstrapForms.default_form_builder.should == MyCustomFormBuilder
+			end
+
+			describe "projects/new.html.erb", :type => :view do
+				before do
+					assign :project, Project.new
+					render :file => "projects/new.html.erb", :layout => "layouts/application.html.erb"
+				end
+
+				it "should render with the other form builder" do
+					# in other words, it shouldn't be wrapped with the bootstrap stuff
+					rendered.should_not match /<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name<\/label><div class=\"controls\">.*<\/div><\/div>/
+				end
+			end
+		end
+	end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
+  config.include RSpec::Rails::ViewExampleGroup, :type => :view
 end
 
 Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
I have a project with a custom field like so:

``` ruby
class MyCustomFormBuilder < ActionView::Helpers::FormBuilder
  def custom_field
  end
end
```

When I added `bootstrap_forms` to the project, I could not use the same functionality. This commit mimics the way ActionView did it (mostly).

So now I can say 

``` ruby
class MyCustomFormBuilder < BootstrapForms::FormBuilder
  def custom_field
  end
end
```

and pop it into the bootstrap_form_for :builder option or put this in an initializer

``` ruby
BootstrapForms::FormBuilder.default_form_builder = MyCustomFormBuilder
```
