### PR TITLE
Very basic support for Symbols inside of bootstrap_form_for.

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -5,7 +5,8 @@ module BootstrapForms
     delegate :content_tag, :hidden_field_tag, :check_box_tag, :radio_button_tag, :button_tag, :link_to, :to => :@template
 
     def error_messages
-      if object.errors.full_messages.any?
+      # return nil if object.is_a?(Symbol)
+      if object.try(:errors) and object.errors.full_messages.any?
         content_tag(:div, :class => 'alert alert-block alert-error validation-errors') do
           content_tag(:h4, I18n.t('bootstrap_forms.errors.header', :model => object.class.model_name.human), :class => 'alert-heading') +
           content_tag(:ul) do
@@ -121,8 +122,8 @@ module BootstrapForms
           extras do
             options = { :class => 'uneditable-input' }
             options[:id] = @field_options[:id] if @field_options[:id]
-            content_tag(:span, options) do 
-              @field_options[:value] || object.send(@name.to_sym)
+            content_tag(:span, options) do
+              @field_options[:value] || object.send(@name.to_sym) rescue nil
             end
           end
         end

--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -5,7 +5,6 @@ module BootstrapForms
     delegate :content_tag, :hidden_field_tag, :check_box_tag, :radio_button_tag, :button_tag, :link_to, :to => :@template
 
     def error_messages
-      # return nil if object.is_a?(Symbol)
       if object.try(:errors) and object.errors.full_messages.any?
         content_tag(:div, :class => 'alert alert-block alert-error validation-errors') do
           content_tag(:h4, I18n.t('bootstrap_forms.errors.header', :model => object.class.model_name.human), :class => 'alert-heading') +

--- a/lib/bootstrap_forms/helpers/form_helper.rb
+++ b/lib/bootstrap_forms/helpers/form_helper.rb
@@ -1,13 +1,17 @@
 module BootstrapForms
   module Helpers
-    module FormHelper      
+    module FormHelper
       def bootstrap_form_for(record, options = {}, &block)
         options[:builder] = BootstrapForms::FormBuilder
         form_for(record, options) do |f|
-          f.error_messages.html_safe + capture(f, &block).html_safe
+          if f.object.respond_to?(:errors)
+            f.error_messages.html_safe + capture(f, &block).html_safe
+          else
+            capture(f, &block).html_safe
+          end
         end
       end
-    
+
       def bootstrap_fields_for(record, options = {}, &block)
         options[:builder] = BootstrapForms::FormBuilder
         fields_for(record, nil, options, &block)

--- a/lib/bootstrap_forms/helpers/wrappers.rb
+++ b/lib/bootstrap_forms/helpers/wrappers.rb
@@ -20,7 +20,7 @@ module BootstrapForms
       end
 
       def error_string
-        if respond_to?(:object)
+        if respond_to?(:object) and object.respond_to?(:errors)
           errors = object.errors[@name]
           if errors.present?
             errors.map { |e|
@@ -31,7 +31,7 @@ module BootstrapForms
       end
 
       def human_attribute_name
-        object.class.human_attribute_name(@name)
+        object.class.human_attribute_name(@name) rescue @name.titleize
       end
 
       def input_div(&block)
@@ -61,7 +61,7 @@ module BootstrapForms
 
       def required_class
         return 'required' if @field_options[:required]
-        if respond_to?(:object)
+        if respond_to?(:object) and object.respond_to?(:errors)
           return 'required' if object.class.validators_on(@name).any? { |v| v.kind_of? ActiveModel::Validations::PresenceValidator }
         end
         nil

--- a/spec/lib/bootstrap_forms/form_builder_spec.rb
+++ b/spec/lib/bootstrap_forms/form_builder_spec.rb
@@ -9,6 +9,8 @@ describe "BootstrapForms::FormBuilder" do
       @builder = BootstrapForms::FormBuilder.new(:item, @project, @template, {}, proc {})
     end
 
+    it_behaves_like 'a bootstrap form'
+
     describe "with no options" do
       describe "error_messages" do
         it "returns empty string without errors" do
@@ -42,182 +44,55 @@ describe "BootstrapForms::FormBuilder" do
           end
         end
       end
+    end
 
-      describe "text_area" do
-        before(:each) do
-          @result = @builder.text_area "name"
-        end
-
-        it "has textarea input" do
-          @result.should match /textarea/
-        end
+    context "with errors" do
+      before(:each) do
+        @project.errors.add("name")
+        @result = @builder.error_messages
       end
 
-      describe "uneditable_input" do 
-        it "generates wrapped input" do
-          @builder.uneditable_input("name").should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><span class=\"uneditable-input\"></span></div></div>"
-        end
-
-        it "allows for an id" do
-          @builder.uneditable_input("name", :id => "myid").should match /<span.*id="myid"/
-        end
+      it "is wrapped in error div" do
+        @result.should match /^<div class="alert alert-block alert-error validation-errors">.*<\/div>$/
       end
 
-      describe "check_box" do
-        it "generates wrapped input" do
-          @builder.check_box("name").should == "<div class=\"control-group\"><div class=\"controls\"><label class=\"checkbox\" for=\"item_name\"><input name=\"item[name]\" type=\"hidden\" value=\"0\" /><input id=\"item_name\" name=\"item[name]\" type=\"checkbox\" value=\"1\" />Name</label></div></div>"
-        end
-
-        it "allows custom label" do
-          @builder.check_box("name", :label => "custom label").should match /custom label<\/label>/
-        end
-
-        it "allows no label with :label => false " do
-          @builder.check_box("name", :label => false).should_not match /<\/label>/
-        end
-        it "allows no label with :label => '' " do
-          @builder.check_box("name", :label => '').should_not match /<\/label>/
-        end
+      it "has a list with errors" do
+        @result.should match /<ul><li>Name is invalid<\/li><\/ul>/
       end
 
-      describe "radio_buttons" do
-        before do
-          if RUBY_VERSION < '1.9'
-            @options = ActiveSupport::OrderedHash.new
-            @options['One'] = '1'
-            @options['Two'] = '2'
-          else
-            @options = {'One' => '1', 'Two' => '2'}
-          end
-        end
-
-        it "doesn't use field_options from previously generated field" do
-          @builder.text_field :name, :label => 'Heading', :help_inline => 'Inline help', :help_block => 'Block help'
-          @builder.radio_buttons(:name, @options).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio\" for=\"item_name_1\"><input id=\"item_name_1\" name=\"item[name]\" type=\"radio\" value=\"1\" />One</label><label class=\"radio\" for=\"item_name_2\"><input id=\"item_name_2\" name=\"item[name]\" type=\"radio\" value=\"2\" />Two</label></div></div>"
-        end
-
-        it "sets field_options" do
-          @builder.radio_buttons(:name, {"One" => "1", "Two" => "2"})
-          @builder.instance_variable_get("@field_options").should == {:error => nil}
-        end
-
-        it "generates wrapped input" do
-          @builder.radio_buttons(:name, @options).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio\" for=\"item_name_1\"><input id=\"item_name_1\" name=\"item[name]\" type=\"radio\" value=\"1\" />One</label><label class=\"radio\" for=\"item_name_2\"><input id=\"item_name_2\" name=\"item[name]\" type=\"radio\" value=\"2\" />Two</label></div></div>"
-        end
-
-        it "allows custom label" do
-          @builder.radio_buttons(:name, @options, {:label => "custom label"}).should match /custom label<\/label>/
-        end
+      it "has error title" do
+        @result.should match /<h4 class="alert-heading">#{I18n.t('bootstrap_forms.errors.header', :model => Project.model_name.human)}<\/h4>/
       end
 
-      (%w{email file number password range search text url }.map{|field| ["#{field}_field",field]} + [["telephone_field", "tel"], ["phone_field", "tel"]]).each do |field, type|
-        describe "#{field}" do
-          context "result" do
-            before(:each) do
-              @result = @builder.send(field, "name")
-            end
-
-            it "is wrapped" do
-              @result.should match /^<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name<\/label><div class=\"controls\">.*<\/div><\/div>$/
-            end
-
-            it "has an input of type: #{type}" do
-              @result.should match /<input.*type="#{type}"/
-            end
-          end # result
-
-          context "call expectations" do
-            %w(control_group_div label_field input_div extras).map(&:to_sym).each do |method|
-              it "calls #{method}" do
-                @builder.should_receive(method).and_return("")
-              end
-            end
-
-            after(:each) do
-              @builder.send(field, "name")
-            end
-          end # call expectations
-
-        end # field
-      end # fields
-    end # no options
-
-    describe "extras" do
-      context "text_field" do
-        it "adds span for inline help" do
-          @builder.text_field(:name, :help_inline => 'help me!').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">help me!</span></div></div>"
-        end
-
-        it "adds help block" do
-          @builder.text_field(:name, :help_block => 'help me!').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><p class=\"help-block\">help me!</p></div></div>"
-        end
-
-        it "adds error message and class" do
-          @builder.text_field(:name, :error => 'This is an error!').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">This is an error!</span></div></div>"
-        end
-
-        it "adds success message and class" do
-          @builder.text_field(:name, :success => 'This checked out OK').should == "<div class=\"control-group success\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">This checked out OK</span></div></div>"
-        end
-
-        it "adds warning message and class" do
-          @builder.text_field(:name, :warning => 'Take a look at this...').should == "<div class=\"control-group warning\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">Take a look at this...</span></div></div>"
-        end
-
-        it "prepends passed text" do
-          @builder.text_field(:name, :prepend => '@').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-prepend\"><span class=\"add-on\">@</span><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /></div></div></div>"
-        end
-
-        it "appends passed text" do
-          @builder.text_field(:name, :append => '@').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-append\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">@</span></div></div></div>"
-        end
-
-        it "prepends and appends passed text" do
-          @builder.text_field(:name, :append => '@', :prepend => '#').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-prepend input-append\"><span class=\"add-on\">\#</span><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">@</span></div></div></div>"
-        end
-      end
-       context "label option" do
-        %w(select email_field file_field number_field password_field search_field text_area text_field url_field).each do |method_name|
-
-          it "should not add a label when ''" do
-            @builder.send(method_name.to_sym, 'name', :label => '').should_not match /<\/label>/
-          end
-
-          it "should not add a label when false" do
-            @builder.send(method_name.to_sym, 'name', :label => false).should_not match /<\/label>/
-          end
-        end
-      end
-    end # extras
-
-    describe "form actions" do
-      context "actions" do
-        it "adds additional block content" do
-          @builder.actions do
-            @builder.submit
-          end.should == "<div class=\"form-actions\"><input class=\"btn btn-primary\" name=\"commit\" type=\"submit\" value=\"Create Project\" /></div>"
-        end
+      it "has error message on field" do
+        @builder.text_field("name").should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">Name is invalid</span></div></div>"
       end
 
-      context "submit" do
-        it "adds btn primary class" do
-          @builder.submit.should == "<input class=\"btn btn-primary\" name=\"commit\" type=\"submit\" value=\"Create Project\" />"
-        end
+      it "joins passed error message and validation errors with ', '" do
+        @builder.text_field("name", :error => 'This is an error!').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">This is an error!, Name is invalid</span></div></div>"
       end
+    end
 
-      context "button" do
-        it "adds btn primary class" do
-          @builder.submit.should == "<input class=\"btn btn-primary\" name=\"commit\" type=\"submit\" value=\"Create Project\" />"
-        end
+    context 'submit' do
+      it 'checks persistence of object' do
+        @builder.submit.should match('Create Project')
       end
+    end
 
-      context "cancel" do
-        it "creates link with correct class" do
-          @builder.should_receive(:link_to).with(I18n.t('bootstrap_forms.buttons.cancel'), :back, :class => 'btn cancel').and_return("")
-          @builder.cancel
-        end
+    context 'button' do
+      it 'checks persistence of object' do
+        @builder.button.should match('Create Project')
       end
-    end # actions
-  end # setup builder
+    end
+  end
 
+  context "given a setup builder with a symbol" do
+    before(:each) do
+      @template = ActionView::Base.new
+      @template.output_buffer = ""
+      @builder = BootstrapForms::FormBuilder.new(:item, nil, @template, {}, proc {})
+    end
+
+    it_behaves_like 'a bootstrap form'
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ require 'active_support/ordered_hash' if RUBY_VERSION < '1.9'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '../lib/bootstrap_forms'))
 
+require 'support/shared_context'
+
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -1,0 +1,184 @@
+shared_examples "a bootstrap form" do
+  describe "with no options" do
+    describe "error_messages" do
+      it "returns empty string without errors" do
+        @builder.error_messages.should == ""
+      end
+    end
+
+    describe "text_area" do
+      before(:each) do
+        @result = @builder.text_area "name"
+      end
+
+      it "has textarea input" do
+        @result.should match /textarea/
+      end
+    end
+
+    describe "uneditable_input" do
+      it "generates wrapped input" do
+        @builder.uneditable_input("name").should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><span class=\"uneditable-input\"></span></div></div>"
+      end
+
+      it "allows for an id" do
+        @builder.uneditable_input("name", :id => "myid").should match /<span.*id="myid"/
+      end
+    end
+
+    describe "check_box" do
+      it "generates wrapped input" do
+        @builder.check_box("name").should == "<div class=\"control-group\"><div class=\"controls\"><label class=\"checkbox\" for=\"item_name\"><input name=\"item[name]\" type=\"hidden\" value=\"0\" /><input id=\"item_name\" name=\"item[name]\" type=\"checkbox\" value=\"1\" />Name</label></div></div>"
+      end
+
+      it "allows custom label" do
+        @builder.check_box("name", :label => "custom label").should match /custom label<\/label>/
+      end
+
+      it "allows no label with :label => false " do
+        @builder.check_box("name", :label => false).should_not match /<\/label>/
+      end
+      it "allows no label with :label => '' " do
+        @builder.check_box("name", :label => '').should_not match /<\/label>/
+      end
+    end
+
+    describe "radio_buttons" do
+      before do
+        if RUBY_VERSION < '1.9'
+          @options = ActiveSupport::OrderedHash.new
+          @options['One'] = '1'
+          @options['Two'] = '2'
+        else
+          @options = {'One' => '1', 'Two' => '2'}
+        end
+      end
+
+      it "doesn't use field_options from previously generated field" do
+        @builder.text_field :name, :label => 'Heading', :help_inline => 'Inline help', :help_block => 'Block help'
+        @builder.radio_buttons(:name, @options).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio\" for=\"item_name_1\"><input id=\"item_name_1\" name=\"item[name]\" type=\"radio\" value=\"1\" />One</label><label class=\"radio\" for=\"item_name_2\"><input id=\"item_name_2\" name=\"item[name]\" type=\"radio\" value=\"2\" />Two</label></div></div>"
+      end
+
+      it "sets field_options" do
+        @builder.radio_buttons(:name, {"One" => "1", "Two" => "2"})
+        @builder.instance_variable_get("@field_options").should == {:error => nil}
+      end
+
+      it "generates wrapped input" do
+        @builder.radio_buttons(:name, @options).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio\" for=\"item_name_1\"><input id=\"item_name_1\" name=\"item[name]\" type=\"radio\" value=\"1\" />One</label><label class=\"radio\" for=\"item_name_2\"><input id=\"item_name_2\" name=\"item[name]\" type=\"radio\" value=\"2\" />Two</label></div></div>"
+      end
+
+      it "allows custom label" do
+        @builder.radio_buttons(:name, @options, {:label => "custom label"}).should match /custom label<\/label>/
+      end
+    end
+
+    (%w{email file number password range search text url }.map{|field| ["#{field}_field",field]} + [["telephone_field", "tel"], ["phone_field", "tel"]]).each do |field, type|
+      describe "#{field}" do
+        context "result" do
+          before(:each) do
+            @result = @builder.send(field, "name")
+          end
+
+          it "is wrapped" do
+            @result.should match /^<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name<\/label><div class=\"controls\">.*<\/div><\/div>$/
+          end
+
+          it "has an input of type: #{type}" do
+            @result.should match /<input.*type="#{type}"/
+          end
+        end # result
+
+        context "call expectations" do
+          %w(control_group_div label_field input_div extras).map(&:to_sym).each do |method|
+            it "calls #{method}" do
+              @builder.should_receive(method).and_return("")
+            end
+          end
+
+          after(:each) do
+            @builder.send(field, "name")
+          end
+        end # call expectations
+
+      end # field
+    end # fields
+  end # no options
+
+  describe "extras" do
+    context "text_field" do
+      it "adds span for inline help" do
+        @builder.text_field(:name, :help_inline => 'help me!').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">help me!</span></div></div>"
+      end
+
+      it "adds help block" do
+        @builder.text_field(:name, :help_block => 'help me!').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><p class=\"help-block\">help me!</p></div></div>"
+      end
+
+      it "adds error message and class" do
+        @builder.text_field(:name, :error => 'This is an error!').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">This is an error!</span></div></div>"
+      end
+
+      it "adds success message and class" do
+        @builder.text_field(:name, :success => 'This checked out OK').should == "<div class=\"control-group success\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">This checked out OK</span></div></div>"
+      end
+
+      it "adds warning message and class" do
+        @builder.text_field(:name, :warning => 'Take a look at this...').should == "<div class=\"control-group warning\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">Take a look at this...</span></div></div>"
+      end
+
+      it "prepends passed text" do
+        @builder.text_field(:name, :prepend => '@').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-prepend\"><span class=\"add-on\">@</span><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /></div></div></div>"
+      end
+
+      it "appends passed text" do
+        @builder.text_field(:name, :append => '@').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-append\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">@</span></div></div></div>"
+      end
+
+      it "prepends and appends passed text" do
+        @builder.text_field(:name, :append => '@', :prepend => '#').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-prepend input-append\"><span class=\"add-on\">\#</span><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">@</span></div></div></div>"
+      end
+    end
+     context "label option" do
+      %w(select email_field file_field number_field password_field search_field text_area text_field url_field).each do |method_name|
+
+        it "should not add a label when ''" do
+          @builder.send(method_name.to_sym, 'name', :label => '').should_not match /<\/label>/
+        end
+
+        it "should not add a label when false" do
+          @builder.send(method_name.to_sym, 'name', :label => false).should_not match /<\/label>/
+        end
+      end
+    end
+  end # extras
+
+  describe "form actions" do
+    context "actions" do
+      it "adds additional block content" do
+        @builder.actions do
+          @builder.submit
+        end.should match(/<div class=\"form-actions\">.*?<\/div>/)
+      end
+    end
+
+    context "submit" do
+      it "adds btn primary class" do
+        @builder.submit.should match /class=\"btn btn-primary\"/
+      end
+    end
+
+    context "button" do
+      it "adds btn primary class" do
+        @builder.button.should match /class=\"btn btn-primary\"/
+      end
+    end
+
+    context "cancel" do
+      it "creates link with correct class" do
+        @builder.should_receive(:link_to).with(I18n.t('bootstrap_forms.buttons.cancel'), :back, :class => 'btn cancel').and_return("")
+        @builder.cancel
+      end
+    end
+  end # actions
+end


### PR DESCRIPTION
This relies on the use of object.respond_to?(:errors) and a few rescues for setting default values to nil.

This gets the ball rolling, but I feel there is probably a cleaner way to do this.
