### PR TITLE
Allow custom classes for submit, cancel and button otherwise default

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -134,7 +134,7 @@ module BootstrapForms
       @field_options = args.extract_options!
       @args = args
 
-      @field_options[:class] = 'btn btn-primary'
+      @field_options[:class] ||= 'btn btn-primary'
       super(name, *(args << @field_options))
     end
 
@@ -143,13 +143,14 @@ module BootstrapForms
       @field_options = args.extract_options!
       @args = args
 
-      @field_options[:class] = 'btn btn-primary'
+      @field_options[:class] ||= 'btn btn-primary'
       super(name, *(args << @field_options))
     end
 
     def cancel(*args)
       @field_options = args.extract_options!
-      link_to(I18n.t('bootstrap_forms.buttons.cancel'), (@field_options[:back] || :back), :class => 'btn cancel')
+      @field_options[:class] ||= 'btn cancel'
+      link_to(I18n.t('bootstrap_forms.buttons.cancel'), (@field_options[:back] || :back), :class => @field_options[:class])
     end
 
     def actions(&block)

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -163,21 +163,32 @@ shared_examples "a bootstrap form" do
     end
 
     context "submit" do
-      it "adds btn primary class" do
+      it "adds btn primary class if no class is defined" do
         @builder.submit.should match /class=\"btn btn-primary\"/
+      end
+      it "allows for custom classes" do
+        @builder.submit(:class => 'btn btn-large btn-success').should match /class=\"btn btn-large btn-success\"/
       end
     end
 
     context "button" do
-      it "adds btn primary class" do
+      it "adds btn primary class if no class is defined" do
         @builder.button.should match /class=\"btn btn-primary\"/
+      end
+      it "allows for custom classes" do
+        @builder.button(:class => 'btn btn-large btn-success').should match /class=\"btn btn-large btn-success\"/
       end
     end
 
     context "cancel" do
-      it "creates link with correct class" do
+      it "creates a link with cancel btn class if no class is defined" do
         @builder.should_receive(:link_to).with(I18n.t('bootstrap_forms.buttons.cancel'), :back, :class => 'btn cancel').and_return("")
         @builder.cancel
+      end
+
+      it "creates a link with custom classes when defined" do
+        @builder.should_receive(:link_to).with(I18n.t('bootstrap_forms.buttons.cancel'), :back, :class => 'btn btn-large my-cancel').and_return("")
+        @builder.cancel(:class => 'btn btn-large my-cancel')
       end
     end
   end # actions


### PR DESCRIPTION
I was thinking there needed to be a way to set a custom classes or even other bootstrap classes to these buttons.

my HAML example:

``` haml

= f.submit 'Post', class: 'btn btn-large btn-success'

```

now renders as:

``` html

<input class="btn btn-large btn-success" name="commit" type="submit" value="Post">

```

What do you think?
