### PR TITLE
radio_buttons wraps individual radios in a label, even if control group has no label

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -58,12 +58,8 @@ module BootstrapForms
       control_group_div do
         label_field + input_div do
           values.map do |text, value|
-            if @field_options[:label] == '' || @field_options[:label] == false
+            label("#{@name}_#{value}", :class => 'radio') do
               extras { radio_button(name, value, @field_options) + text }
-            else
-              label("#{@name}_#{value}", :class => 'radio') do
-                extras { radio_button(name, value, @field_options) + text }
-              end
             end
           end.join.html_safe
         end

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -71,6 +71,10 @@ shared_examples "a bootstrap form" do
       it "allows custom label" do
         @builder.radio_buttons(:name, @options, {:label => "custom label"}).should match /custom label<\/label>/
       end
+      
+      it "allows no label" do
+        @builder.radio_buttons(:name, @options, {:label => false}).should == "<div class=\"control-group\"><div class=\"controls\"><label class=\"radio\" for=\"item_name_1\"><input id=\"item_name_1\" name=\"item[name]\" type=\"radio\" value=\"1\" />One</label><label class=\"radio\" for=\"item_name_2\"><input id=\"item_name_2\" name=\"item[name]\" type=\"radio\" value=\"2\" />Two</label></div></div>"
+      end
     end
 
     (%w{email file number password range search text url }.map{|field| ["#{field}_field",field]} + [["telephone_field", "tel"], ["phone_field", "tel"]]).each do |field, type|


### PR DESCRIPTION
Currently, individual radio buttons are not wrapped in `<label class="radio">` if `label: false` is passed, so the text is misaligned.
