### PR TITLE
Added :control_group option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -183,6 +183,11 @@ You can add as many options to any form helper tag. If they are interpreted by B
     <td>Customize the field's label. Pass false to have no label.</td>
     <td><tt>= f.text_field :name, :label => 'Other name'</td></td>
   </tr>
+  <tr>
+    <th>control_group</th>
+    <td>Pass false to remove the control group and controls HTML, leaving only the label and input, wrapped in a plain div</td>
+    <td><tt>= f.text_field :name, :control_group => false</tt></td>
+  </tr>
 </table>
 
 Internationalization/Custom Errors

--- a/lib/bootstrap_forms/helpers/wrappers.rb
+++ b/lib/bootstrap_forms/helpers/wrappers.rb
@@ -10,12 +10,16 @@ module BootstrapForms
           @field_options[:error] = field_errors
         end
 
-        klasses = ['control-group']
+        klasses = []
+        klasses << 'control-group' unless @field_options[:control_group] == false
         klasses << 'error' if @field_options[:error]
         klasses << 'success' if @field_options[:success]
         klasses << 'warning' if @field_options[:warning]
+        
+        control_group_options = {}
+        control_group_options[:class] = klasses if !klasses.empty?
 
-        content_tag(:div, :class => klasses, &block)
+        content_tag(:div, control_group_options, &block)
       end
 
       def error_string
@@ -34,15 +38,26 @@ module BootstrapForms
       end
 
       def input_div(&block)
-        content_tag(:div, :class => 'controls') do
-          if @field_options[:append] || @field_options[:prepend] || @field_options[:append_button]
-            klass = []
-            klass << 'input-prepend' if @field_options[:prepend]
-            klass << 'input-append' if @field_options[:append] || @field_options[:append_button]
-            content_tag(:div, :class => klass, &block)
-          else
-            yield if block_given?
+        content_options = {}
+        content_options[:class] = 'controls' 
+        if @field_options[:control_group] == false
+          @field_options.delete :control_group
+          write_input_div(&block)
+        else
+          content_tag(:div, :class => 'controls') do
+            write_input_div(&block)
           end
+        end
+      end
+      
+      def write_input_div(&block)
+        if @field_options[:append] || @field_options[:prepend] || @field_options[:append_button]
+          klass = []
+          klass << 'input-prepend' if @field_options[:prepend]
+          klass << 'input-append' if @field_options[:append] || @field_options[:append_button]
+          content_tag(:div, :class => klass, &block)
+        else
+          yield if block_given?
         end
       end
 
@@ -50,10 +65,12 @@ module BootstrapForms
         if @field_options[:label] == '' || @field_options[:label] == false
           return ''.html_safe
         else
+          label_options = {}
+          label_options[:class] = 'control-label' unless @field_options[:control_group] == false
           if respond_to?(:object)
-             label(@name, block_given? ? block : @field_options[:label], :class => 'control-label')
+             label(@name, block_given? ? block : @field_options[:label], label_options)
            else
-             label_tag(@name, block_given? ? block : @field_options[:label], :class => 'control-label')
+             label_tag(@name, block_given? ? block : @field_options[:label], label_options)
            end
         end
       end
@@ -107,7 +124,7 @@ module BootstrapForms
       end
 
       def objectify_options(options)
-        super.except(:label, :help_inline, :error, :success, :warning, :help_block, :prepend, :append, :append_button)
+        super.except(:label, :help_inline, :error, :success, :warning, :help_block, :prepend, :append, :append_button, :control_group)
       end
     end
   end

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -158,6 +158,14 @@ shared_examples 'a bootstrap form' do
       it 'appends button with an icon' do
         @builder.text_field(:name, :append_button => { :label => 'button label', :icon => 'icon-plus icon-white' }).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-append\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><button class=\"btn\" type=\"button\"><i class=\"icon-plus icon-white\"></i> button label</button></div></div></div>"
       end
+
+      it "does not add control group" do
+        @builder.text_field(:name, :control_group => false).should == "<div><label for=\"item_name\">Name</label><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /></div>"
+      end
+
+      it "does not add control group attribute to html if :control_group is true" do
+        @builder.text_field(:name, :control_group => true).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /></div></div>"
+      end
     end
 
     context 'label option' do


### PR DESCRIPTION
This option removes most of the form row HTML, such as the control-group, control-label and controls blocks.

I've found this handy for things like putting more than one form field on a single line, or generally getting fine-grained layout control without losing bootstrap_forms's benefits and nice API.
