### PR TITLE
Cancel and button helper

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -150,7 +150,9 @@ module BootstrapForms
     def cancel(*args)
       @field_options = field_options(args)
       @field_options[:class] ||= 'btn cancel'
-      link_to(I18n.t('bootstrap_forms.buttons.cancel'), (@field_options[:back] || :back), :class => @field_options[:class])
+      @field_options[:name] ||= I18n.t('bootstrap_forms.buttons.cancel')
+      @field_options[:back] ||= :back
+      link_to(@field_options[:name], @field_options[:back], :class => @field_options[:class])
     end
 
     def actions(&block)

--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -134,7 +134,7 @@ module BootstrapForms
       @field_options = field_options(args)
       @args = args
 
-      @field_options[:class] ||= 'btn btn-primary'
+      @field_options[:class] ||= 'btn'
       super(name, *(args << @field_options))
     end
 

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -221,6 +221,12 @@ shared_examples 'a bootstrap form' do
         @builder.should_receive(:link_to).with(I18n.t('bootstrap_forms.buttons.cancel'), :back, :class => 'btn btn-large my-cancel').and_return("")
         @builder.cancel(:class => 'btn btn-large my-cancel')
       end
+
+      it 'creates a link with a custom name when defined' do
+        name = 'Back'
+        @builder.should_receive(:link_to).with(name, :back, :class => 'btn cancel').and_return("")
+        @builder.cancel(:name => name)
+      end
     end
   end # actions
 end

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -116,7 +116,7 @@ shared_examples 'a bootstrap form' do
       end
 
       it 'adds help block' do
-        @builder.text_field(:name, :help_block => 'help me!').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><p class=\"help-block\">help me!</p></div></div>"
+        @builder.text_field(:name, :help_block => 'help me!').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-block\">help me!</span></div></div>"
       end
 
       it 'adds error message and class' do

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -202,8 +202,8 @@ shared_examples 'a bootstrap form' do
     end
 
     context 'button' do
-      it 'adds btn primary class if no class is defined' do
-        @builder.button.should match /class=\"btn btn-primary\"/
+      it 'adds btn class if no class is defined' do
+        @builder.button.should match /class=\"btn\"/
       end
 
       it 'allows for custom classes' do


### PR DESCRIPTION
- Fixed an issue in the shared spec where the incorrect type of tag was being expected
- Added the ability to specify a custom label for a Cancel button
- Changed the default styling for Button to be different from that of Submit
