### PR TITLE
Let individual input required-ness be overridden

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -188,6 +188,11 @@ You can add as many options to any form helper tag. If they are interpreted by B
     <td>Pass false to remove the control group and controls HTML, leaving only the label and input, wrapped in a plain div</td>
     <td><tt>= f.text_field :name, :control_group => false</tt></td>
   </tr>
+  <tr>
+    <th>:required => false</th>
+    <td>Pass false to ignore presence validation checks that add a required attribute on the generated element.</td>
+    <td><tt>= f.text_field :name, :required => false</tt></td>
+  </tr>
 </table>
 
 Internationalization/Custom Errors

--- a/lib/bootstrap_forms/helpers/wrappers.rb
+++ b/lib/bootstrap_forms/helpers/wrappers.rb
@@ -76,6 +76,8 @@ module BootstrapForms
       end
 
       def required_attribute
+        return {} if @field_options.present? && @field_options.has_key?(:required) && !@field_options[:required]
+        
         if respond_to?(:object) and object.respond_to?(:errors) and object.class.respond_to?('validators_on')
           return { :required => true } if object.class.validators_on(@name).any? { |v| v.kind_of?( ActiveModel::Validations::PresenceValidator ) && valid_validator?( v ) }
         end

--- a/spec/lib/bootstrap_forms/form_builder_spec.rb
+++ b/spec/lib/bootstrap_forms/form_builder_spec.rb
@@ -96,7 +96,7 @@ describe 'BootstrapForms::FormBuilder' do
         @builder.text_field('owner').should match /<input .*required="required"/
       end
       
-      it "does not add the required if required: false" do
+      it "does not add the required attribute if required: false" do
         @builder.text_field('owner', required: false).should_not match /<input .*required="required"/
       end
       

--- a/spec/lib/bootstrap_forms/form_builder_spec.rb
+++ b/spec/lib/bootstrap_forms/form_builder_spec.rb
@@ -97,7 +97,7 @@ describe 'BootstrapForms::FormBuilder' do
       end
       
       it "does not add the required attribute if required: false" do
-        @builder.text_field('owner', required: false).should_not match /<input .*required="required"/
+        @builder.text_field('owner', :required => false).should_not match /<input .*required="required"/
       end
       
       it "not require if or unless validators" do

--- a/spec/lib/bootstrap_forms/form_builder_spec.rb
+++ b/spec/lib/bootstrap_forms/form_builder_spec.rb
@@ -96,6 +96,10 @@ describe 'BootstrapForms::FormBuilder' do
         @builder.text_field('owner').should match /<input .*required="required"/
       end
       
+      it "does not add the required if required: false" do
+        @builder.text_field('owner', required: false).should_not match /<input .*required="required"/
+      end
+      
       it "not require if or unless validators" do
         @builder.text_field('if_presence').should_not match /<input .*required="required"/
         @builder.text_field('unless_presence').should_not match /<input .*required="required"/
@@ -118,7 +122,6 @@ describe 'BootstrapForms::FormBuilder' do
         @project.stub!(:persisted?).and_return(true)
         @builder.text_field('create_presence').should_not match /<input .*required="required"/
       end
-      
     end
 
     context 'submit' do


### PR DESCRIPTION
In my case I have a model with required fields. If they're not set in the UI on create I generate them for the user. I don't want these elements to get a required attribute.

Specs pass and the negative test case was already there. Happy to tweak it, let me know!
