### PR TITLE
Fixed HTML structure when :append and :help_inline, :error, etc. are used simultaneously

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -30,7 +30,9 @@ module BootstrapForms
 
         control_group_div do
           label_field + input_div do
-            extras { super(name, @args.merge(@field_options.merge(required_attribute))) }
+            merged_args = @args.merge(@field_options.merge(required_attribute))
+            input_append = (merged_args[:append] || merged_args[:prepend] || merged_args[:append_button]) ? true : nil
+            extras(input_append) { super(name, merged_args) }
           end
         end
       end

--- a/lib/bootstrap_forms/helpers/wrappers.rb
+++ b/lib/bootstrap_forms/helpers/wrappers.rb
@@ -59,7 +59,9 @@ module BootstrapForms
           klass = []
           klass << 'input-prepend' if @field_options[:prepend]
           klass << 'input-append' if @field_options[:append] || @field_options[:append_button]
-          content_tag(:div, :class => klass, &block)
+          html = content_tag(:div, :class => klass, &block)
+          html << extras(false, &block) if @field_options[:help_inline] || @field_options[:help_block] || @field_options[:error] || @field_options[:success] || @field_options[:warning]
+          html
         else
           yield if block_given?
         end
@@ -146,8 +148,15 @@ module BootstrapForms
         end
       end
 
-      def extras(&block)
-        [prepend, (yield if block_given?), append, append_button, help_inline, error, success, warning, help_block].join('').html_safe
+      def extras(input_append = nil, &block)
+        case input_append
+        when nil
+          [prepend, (yield if block_given?), append, append_button, help_inline, error, success, warning, help_block].join('').html_safe
+        when true
+          [prepend, (yield if block_given?), append, append_button].join('').html_safe
+        when false
+          [help_inline, error, success, warning, help_block].join('').html_safe
+        end
       end
 
       def objectify_options(options)

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -152,6 +152,10 @@ shared_examples 'a bootstrap form' do
         @builder.text_field(:name, :error => 'This is an error!').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">This is an error!</span></div></div>"
       end
 
+      it 'adds error message, class and appended text' do
+        @builder.text_field(:name, :error => 'This is an error!', :append => 'test').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-append\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">test</span></div><span class=\"help-inline\">This is an error!</span></div></div>"
+      end
+
       it 'adds success message and class' do
         @builder.text_field(:name, :success => 'This checked out OK').should == "<div class=\"control-group success\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">This checked out OK</span></div></div>"
       end
@@ -170,6 +174,14 @@ shared_examples 'a bootstrap form' do
 
       it 'prepends and appends passed text' do
         @builder.text_field(:name, :append => '@', :prepend => '#').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-prepend input-append\"><span class=\"add-on\">\#</span><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">@</span></div></div></div>"
+      end
+
+      it 'prepends, appends and adds inline help' do
+        @builder.text_field(:name, :append => '@', :prepend => '#', :help_inline => 'some help').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-prepend input-append\"><span class=\"add-on\">\#</span><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">@</span></div><span class=\"help-inline\">some help</span></div></div>"
+      end
+
+      it 'prepends, appends and adds block help' do
+        @builder.text_field(:name, :append => '@', :prepend => '#', :help_block => 'some help').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-prepend input-append\"><span class=\"add-on\">\#</span><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">@</span></div><span class=\"help-block\">some help</span></div></div>"
       end
 
       it 'appends button with default values' do


### PR DESCRIPTION
Help, error, success, etc. messages did not appear when `:append`, `:append_button` or `:prepend` were used at the same time as `:help_inline`, `:help_block`, `:error` and similar options.

I haven't exhaustively tested every combination.

I find my code a bit messy, but don't have the time/ideas to make it better right now. Feedback on possible improvements would be much appreciated.
