### PR TITLE
Replaced deprecated `source :rubygems' with recommended `source "https://rubygems.org"'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source "https://rubygems.org"
 gemspec


### PR DESCRIPTION
As said by Bundler when you're installing the gems:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
