### PR TITLE
Added boolean option :full_error_messages to bootstrap_form_for

### DIFF
--- a/lib/bootstrap_forms/helpers/form_helper.rb
+++ b/lib/bootstrap_forms/helpers/form_helper.rb
@@ -4,8 +4,12 @@ module BootstrapForms
       def bootstrap_form_for(record, options = {}, &block)
         options[:builder] ||= BootstrapForms.default_form_builder
 
-        form_for(record, options) do |f|
-          if f.object.respond_to?(:errors)
+        form_options = options.deep_dup
+        options[:summary_errors] = true unless form_options.has_key?(:summary_errors)
+        form_options.delete(:summary_errors)
+
+        form_for(record, form_options) do |f|
+          if f.object.respond_to?(:errors) and options[:summary_errors]
             f.error_messages.html_safe + capture(f, &block).html_safe
           else
             capture(f, &block).html_safe

--- a/spec/dummy/app/views/projects/new_without_summary_errors.html.erb
+++ b/spec/dummy/app/views/projects/new_without_summary_errors.html.erb
@@ -1,0 +1,4 @@
+<%= bootstrap_form_for @project, :summary_errors => false do |f| -%>
+  <%= f.text_field :name %>
+  <%= f.submit %>
+<% end -%>

--- a/spec/lib/bootstrap_forms/bootstrap_form_for_spec.rb
+++ b/spec/lib/bootstrap_forms/bootstrap_form_for_spec.rb
@@ -10,6 +10,19 @@ describe 'bootstrap_form_for' do
       BootstrapForms.default_form_builder.should == BootstrapForms::FormBuilder
     end
 
+    context 'projects/new_without_summary_errors.html.erb', :type => :view do
+      before do
+        project = Project.new
+        project.errors.add('name')
+        assign :project, project
+        render :file => 'projects/new_without_summary_errors', :layout => 'layouts/application', :handlers => [:erb]
+      end
+
+      it 'should not render the full error messages div' do
+        rendered.should_not match /There were errors that prevented this Project from being saved/
+      end
+    end
+
     context 'when set to something else' do
       before do
         BootstrapForms.default_form_builder = MyCustomFormBuilder


### PR DESCRIPTION
Allow the form to not render the div containing full error messages.
As indicated in the new test, if you write the following, you won't get the error_messages div.

```
<%= bootstrap_form_for @project, full_error_messages: false do |f| %>
  <%= f.text_field :name %>
  <%= f.submit %>
<% end %>
```

The normal behaviour hasn't been altered.
