### PR TITLE
use I18n errors.format key to generate field error message

### DIFF
--- a/lib/bootstrap_forms/helpers/wrappers.rb
+++ b/lib/bootstrap_forms/helpers/wrappers.rb
@@ -31,7 +31,7 @@ module BootstrapForms
           errors = object.errors[@name]
           if errors.present?
             errors.map { |e|
-              "#{@options[:label] || human_attribute_name} #{e}"
+              object.errors.full_message(@name, e)
             }.join(", ")
           end
         end

--- a/spec/lib/bootstrap_forms/form_builder_spec.rb
+++ b/spec/lib/bootstrap_forms/form_builder_spec.rb
@@ -90,6 +90,20 @@ describe 'BootstrapForms::FormBuilder' do
         @builder.text_field('name', :error => 'This is an error!').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">This is an error!, Name is invalid</span></div></div>"
       end
     end
+    
+    context "errors with translations" do
+      before(:all) { I18n.backend.store_translations I18n.locale, {errors: {format: "%{message}", messages: {invalid: "Nope"}}} }
+      after(:all)  { I18n.backend.reload! }
+      
+      before(:each) do
+        @project.errors.add('name')
+        @result = @builder.error_messages
+      end
+      
+      it 'use i18n format on field error message' do
+        @builder.text_field('name').should match /<span class="help-inline">Nope<\/span>/
+      end
+    end
 
     context 'an attribute with a PresenceValidator' do
       it 'adds the required attribute' do


### PR DESCRIPTION
Rails uses the translation key "errors.format" to generate the error message on fields, instead of just concatenating the field name and the error. This patch uses ActiveModel [`full_message`](https://github.com/rails/rails/blob/127411fdf3a3470e8830abf0c7876db67c0c344a/activemodel/lib/active_model/errors.rb#L286) to do the same.
