### PR TITLE
Rails extra fix 

### DIFF
--- a/lib/bootstrap_forms/helpers/wrappers.rb
+++ b/lib/bootstrap_forms/helpers/wrappers.rb
@@ -1,6 +1,8 @@
 module BootstrapForms
   module Helpers
     module Wrappers
+      BOOTSTRAP_OPTIONS = [ :label, :help_inline, :error, :success, :warning, :help_block, :prepend, :append, :append_button, :control_group ]
+
       private
       def control_group_div(&block)
         field_errors = error_string
@@ -164,7 +166,7 @@ module BootstrapForms
       end
 
       def objectify_options(options)
-        super.except(:label, :help_inline, :error, :success, :warning, :help_block, :prepend, :append, :append_button, :control_group)
+        super.except(*BOOTSTRAP_OPTIONS)
       end
     end
   end

--- a/spec/lib/bootstrap_forms/form_builder_spec.rb
+++ b/spec/lib/bootstrap_forms/form_builder_spec.rb
@@ -90,16 +90,16 @@ describe 'BootstrapForms::FormBuilder' do
         @builder.text_field('name', :error => 'This is an error!').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline error-message\">This is an error!, Name is invalid</span></div></div>"
       end
     end
-    
+
     context "errors with translations" do
       before(:all) { I18n.backend.store_translations I18n.locale, {:errors => {:format => "%{message}", :messages => {:invalid => "Nope"}}} }
       after(:all)  { I18n.backend.reload! }
-      
+
       before(:each) do
         @project.errors.add('name')
         @result = @builder.error_messages
       end
-      
+
       it 'use i18n format on field error message' do
         @builder.text_field('name').should match /<span class="help-inline error-message">Nope<\/span>/
       end
@@ -153,7 +153,8 @@ describe 'BootstrapForms::FormBuilder' do
 
   context 'setup builder with a symbol' do
     before(:each) do
-      @template = ActionView::Base.new
+      @project = Project.new
+      @template = ActionView::Base.new(nil, :item => @project)
       @template.output_buffer = ''
       @builder = BootstrapForms::FormBuilder.new(:item, nil, @template, {}, proc {})
     end

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -80,7 +80,11 @@ shared_examples 'a bootstrap form' do
       it 'adds inline class' do
         @builder.radio_buttons(:name, @options, {:inline => true}).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio inline\" for=\"item_name_1\"><input id=\"item_name_1\" name=\"item[name]\" type=\"radio\" value=\"1\" />One</label><label class=\"radio inline\" for=\"item_name_2\"><input id=\"item_name_2\" name=\"item[name]\" type=\"radio\" value=\"2\" />Two</label></div></div>"
       end
-      
+
+      it 'adds block help' do
+        @builder.radio_buttons(:name, @options, :help_block => "Help me!").should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio\" for=\"item_name_1\"><input id=\"item_name_1\" name=\"item[name]\" type=\"radio\" value=\"1\" />One</label><label class=\"radio\" for=\"item_name_2\"><input id=\"item_name_2\" name=\"item[name]\" type=\"radio\" value=\"2\" />Two</label><span class=\"help-block\">Help me!</span></div></div>"
+      end
+
       describe "with disabled option" do
         before do
           @options = {'One' => '1', 'Two' => {:value => '2', :disabled => true}}
@@ -122,6 +126,34 @@ shared_examples 'a bootstrap form' do
 
       end # field
     end # fields
+
+    describe 'collection_radio_buttons' do
+      before do
+        @options = [ [["foo", "Foo"], ["bar", "Bar"]], :first, :last ]
+      end
+
+      it 'generates wrapped input' do
+        @builder.collection_radio_buttons(:name, *@options).should eq "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio\"><input id=\"item_name_foo\" name=\"item[name]\" type=\"radio\" value=\"foo\" />Foo</label><label class=\"radio\"><input id=\"item_name_bar\" name=\"item[name]\" type=\"radio\" value=\"bar\" />Bar</label></div></div>"
+      end
+
+      it 'adds block help' do
+        @builder.collection_radio_buttons(:name, *@options, :help_block => "Help me!").should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio\"><input id=\"item_name_foo\" name=\"item[name]\" type=\"radio\" value=\"foo\" />Foo</label><label class=\"radio\"><input id=\"item_name_bar\" name=\"item[name]\" type=\"radio\" value=\"bar\" />Bar</label><span class=\"help-block\">Help me!</span></div></div>"
+      end
+    end
+
+    describe 'collection_check_boxes' do
+      before do
+        @options = [ [["foo", "Foo"], ["bar", "Bar"]], :first, :last ]
+      end
+
+      it 'generates wrapped input' do
+        @builder.collection_check_boxes(:name, *@options).should eq "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"checkbox\"><input id=\"item_name_foo\" name=\"item[name][]\" type=\"checkbox\" value=\"foo\" />Foo</label><label class=\"checkbox\"><input id=\"item_name_bar\" name=\"item[name][]\" type=\"checkbox\" value=\"bar\" />Bar</label></div></div>"
+      end
+
+      it 'adds block help' do
+        @builder.collection_check_boxes(:name, *@options, :help_block => "Help me!").should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"checkbox\"><input id=\"item_name_foo\" name=\"item[name][]\" type=\"checkbox\" value=\"foo\" />Foo</label><label class=\"checkbox\"><input id=\"item_name_bar\" name=\"item[name][]\" type=\"checkbox\" value=\"bar\" />Bar</label><span class=\"help-block\">Help me!</span></div></div>"
+      end
+    end
 
     describe 'collection select' do
       before(:each) do


### PR DESCRIPTION
RE issue #92 

After some thought, I opted to make `radio_buttons` mimic `collection_radio_buttons` (which themselves might use a few tweaks) though this makes it consistant, at least. 

I also found that `collection_radio_buttons` and `collection_check_boxes` assume that `object` is an object when in certain instances the builder was passed a `Symbol` and `object` is `nil`. And, since the `*_tag` versions were used the symbol is never looked up.  I was able to resolve this for `collection_radio_buttons` by using the builder's `radio_button` method but things are a little tricky with check boxes. Hence the failing tests in Travis.

`ActionView::Helpers::FormHelper.check_box` could be used or one can get the instance var. AFAIK the other helpers have issues in this case.

Oh also, the `collection_*` methods included the Bootstrap options in the `input` element's attributes. This is fixed. 
