### PR TITLE
do not modify the hash passed in append_button

### DIFF
--- a/lib/bootstrap_forms/helpers/wrappers.rb
+++ b/lib/bootstrap_forms/helpers/wrappers.rb
@@ -129,7 +129,7 @@ module BootstrapForms
             tag_options[:class] = 'add-on'
           when 'append_button'
             element = :button
-            button_options = value
+            button_options = value.dup
             value = ''
 
             if button_options.has_key? :icon

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -289,6 +289,13 @@ shared_examples 'a bootstrap form' do
         @builder.text_field(:name, :append_button => { :label => 'button label', :icon => 'icon-plus icon-white' }).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-append\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><button class=\"btn\" type=\"button\"><i class=\"icon-plus icon-white\"></i> button label</button></div></div></div>"
       end
 
+      it 'appends button twice with same options' do
+        options = { :label => 'button label', :icon => 'icon-plus icon-white' }
+        first = @builder.text_field(:name, :append_button => options)
+        second = @builder.text_field(:name, :append_button => options)
+        second.should == first
+      end
+
       it "does not add control group" do
         @builder.text_field(:name, :control_group => false).should == "<label for=\"item_name\">Name</label><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" />"
       end


### PR DESCRIPTION
The hash passed in `append_button` is modified. This is problematic when you want to reuse the options.
