### PR TITLE
Insert whitespace before help-inline span

### DIFF
--- a/lib/bootstrap_forms/helpers/wrappers.rb
+++ b/lib/bootstrap_forms/helpers/wrappers.rb
@@ -162,9 +162,9 @@ module BootstrapForms
               content_tag(:button, value, options, false)
             end.join
           when 'error', 'success', 'warning'
-            content_tag(:span, value, :class => "help-inline #{method_name}-message")
+            ' ' + content_tag(:span, value, :class => "help-inline #{method_name}-message")
           else
-            content_tag(:span, value, :class => 'help-inline')
+            ' ' + content_tag(:span, value, :class => 'help-inline')
           end
         end
       end

--- a/spec/lib/bootstrap_forms/form_builder_spec.rb
+++ b/spec/lib/bootstrap_forms/form_builder_spec.rb
@@ -83,11 +83,11 @@ describe 'BootstrapForms::FormBuilder' do
       end
 
       it 'have error message on field' do
-        @builder.text_field('name').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline error-message\">Name is invalid</span></div></div>"
+        @builder.text_field('name').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /> <span class=\"help-inline error-message\">Name is invalid</span></div></div>"
       end
 
       it "joins passed error message and validation errors with ', '" do
-        @builder.text_field('name', :error => 'This is an error!').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline error-message\">This is an error!, Name is invalid</span></div></div>"
+        @builder.text_field('name', :error => 'This is an error!').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /> <span class=\"help-inline error-message\">This is an error!, Name is invalid</span></div></div>"
       end
     end
 

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -251,7 +251,7 @@ shared_examples 'a bootstrap form' do
   describe 'extras' do
     context 'text_field' do
       it 'adds span for inline help' do
-        @builder.text_field(:name, :help_inline => 'help me!').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline\">help me!</span></div></div>"
+        @builder.text_field(:name, :help_inline => 'help me!').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /> <span class=\"help-inline\">help me!</span></div></div>"
       end
 
       it 'adds help block' do
@@ -263,19 +263,19 @@ shared_examples 'a bootstrap form' do
       end
 
       it 'adds error message and class' do
-        @builder.text_field(:name, :error => 'This is an error!').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline error-message\">This is an error!</span></div></div>"
+        @builder.text_field(:name, :error => 'This is an error!').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /> <span class=\"help-inline error-message\">This is an error!</span></div></div>"
       end
 
       it 'adds error message, class and appended text' do
-        @builder.text_field(:name, :error => 'This is an error!', :append => 'test').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-append\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">test</span></div><span class=\"help-inline error-message\">This is an error!</span></div></div>"
+        @builder.text_field(:name, :error => 'This is an error!', :append => 'test').should == "<div class=\"control-group error\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-append\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">test</span></div> <span class=\"help-inline error-message\">This is an error!</span></div></div>"
       end
 
       it 'adds success message and class' do
-        @builder.text_field(:name, :success => 'This checked out OK').should == "<div class=\"control-group success\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline success-message\">This checked out OK</span></div></div>"
+        @builder.text_field(:name, :success => 'This checked out OK').should == "<div class=\"control-group success\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /> <span class=\"help-inline success-message\">This checked out OK</span></div></div>"
       end
 
       it 'adds warning message and class' do
-        @builder.text_field(:name, :warning => 'Take a look at this...').should == "<div class=\"control-group warning\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"help-inline warning-message\">Take a look at this...</span></div></div>"
+        @builder.text_field(:name, :warning => 'Take a look at this...').should == "<div class=\"control-group warning\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /> <span class=\"help-inline warning-message\">Take a look at this...</span></div></div>"
       end
 
       it 'prepends passed text' do
@@ -291,7 +291,7 @@ shared_examples 'a bootstrap form' do
       end
 
       it 'prepends, appends and adds inline help' do
-        @builder.text_field(:name, :append => '@', :prepend => '#', :help_inline => 'some help').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-prepend input-append\"><span class=\"add-on\">\#</span><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">@</span></div><span class=\"help-inline\">some help</span></div></div>"
+        @builder.text_field(:name, :append => '@', :prepend => '#', :help_inline => 'some help').should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><div class=\"input-prepend input-append\"><span class=\"add-on\">\#</span><input id=\"item_name\" name=\"item[name]\" size=\"30\" type=\"text\" /><span class=\"add-on\">@</span></div> <span class=\"help-inline\">some help</span></div></div>"
       end
 
       it 'prepends, appends and adds block help' do


### PR DESCRIPTION
Rails will add error messages that are meant to be read in the context
of the label. Without some whitespace between the tags, page content
will be joined and automated tests will not find expected text.

i.e. When running a capybara spec, where a name field that cannot be
blank, the errors would result in a page text of

"Namecan't be blank"

Adding whitespace before the span tag should not result in a visible
difference in the browser.
