### PR TITLE
Bootstrap now uses checkbox-inline and radio-inline classes

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -91,7 +91,7 @@ module BootstrapForms
             extras { super(name, @args.merge(@field_options)) }
           else
             klasses = 'checkbox'
-            klasses << ' inline' if @field_options.delete(:inline) == true
+            klasses << '-inline' if @field_options.delete(:inline) == true
             @args.delete :inline
             label(@name, :class => klasses) do
               extras { super(name, @args.merge(@field_options), checked_value, unchecked_value) + (@field_options[:label].blank? ? human_attribute_name : @field_options[:label])}
@@ -107,7 +107,7 @@ module BootstrapForms
       control_group_div do
         label_field + input_div do
           klasses = 'radio'
-          klasses << ' inline' if @field_options.delete(:inline) == true
+          klasses << '-inline' if @field_options.delete(:inline) == true
 
           buttons = values.map do |text, value|
             radio_options = @field_options

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -46,7 +46,7 @@ shared_examples 'a bootstrap form' do
       end
 
       it 'adds inline class' do
-        @builder.check_box('name', :inline => true).should  == "<div class=\"control-group\"><div class=\"controls\"><label class=\"checkbox inline\" for=\"item_name\"><input name=\"item[name]\" type=\"hidden\" value=\"0\" /><input id=\"item_name\" name=\"item[name]\" type=\"checkbox\" value=\"1\" />Name</label></div></div>"
+        @builder.check_box('name', :inline => true).should  == "<div class=\"control-group\"><div class=\"controls\"><label class=\"checkbox-inline\" for=\"item_name\"><input name=\"item[name]\" type=\"hidden\" value=\"0\" /><input id=\"item_name\" name=\"item[name]\" type=\"checkbox\" value=\"1\" />Name</label></div></div>"
       end
 
       it 'uses passed values' do
@@ -94,7 +94,7 @@ shared_examples 'a bootstrap form' do
       end
 
       it 'adds inline class' do
-        @builder.radio_buttons(:name, @options, {:inline => true}).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio inline\" for=\"item_name_1\"><input id=\"item_name_1\" name=\"item[name]\" type=\"radio\" value=\"1\" />One</label><label class=\"radio inline\" for=\"item_name_2\"><input id=\"item_name_2\" name=\"item[name]\" type=\"radio\" value=\"2\" />Two</label></div></div>"
+        @builder.radio_buttons(:name, @options, {:inline => true}).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio-inline\" for=\"item_name_1\"><input id=\"item_name_1\" name=\"item[name]\" type=\"radio\" value=\"1\" />One</label><label class=\"radio-inline\" for=\"item_name_2\"><input id=\"item_name_2\" name=\"item[name]\" type=\"radio\" value=\"2\" />Two</label></div></div>"
       end
 
       it 'adds block help' do


### PR DESCRIPTION
Bootstrap changed the inline classes. See http://getbootstrap.com/css/#forms-controls
