### PR TITLE
Sanitize value in label for

### DIFF
--- a/lib/bootstrap_forms/form_builder.rb
+++ b/lib/bootstrap_forms/form_builder.rb
@@ -101,6 +101,10 @@ module BootstrapForms
       end
     end
 
+    def sanitized_value(value)
+      value.to_s.gsub(/\s/, "_").gsub(/[^-\w]/, "").downcase
+    end
+
     def radio_buttons(name, values = {}, opts = {})
       @name = name
       @field_options = @options.slice(:namespace, :index).merge(opts.merge(required_attribute))
@@ -116,7 +120,7 @@ module BootstrapForms
               value = radio_options.delete(:value)
             end
 
-            label("#{@name}_#{value}", :class => klasses) do
+            label("#{@name}_#{sanitized_value value}", :class => klasses) do
               radio_button(name, value, radio_options) + text
             end
           end.join('')

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -81,6 +81,10 @@ shared_examples 'a bootstrap form' do
         @builder.instance_variable_get('@field_options').should == {:error => nil}
       end
 
+      it 'sanitizes values in id and label for' do
+        @builder.radio_buttons(:name, {'One' => '1.0', 'Two' => '2$&-!3'}).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio\" for=\"item_name_10\"><input id=\"item_name_10\" name=\"item[name]\" type=\"radio\" value=\"1.0\" />One</label><label class=\"radio\" for=\"item_name_2-3\"><input id=\"item_name_2-3\" name=\"item[name]\" type=\"radio\" value=\"2$&amp;-!3\" />Two</label></div></div>"
+      end
+
       it 'generates wrapped input' do
         @builder.radio_buttons(:name, @options).should == "<div class=\"control-group\"><label class=\"control-label\" for=\"item_name\">Name</label><div class=\"controls\"><label class=\"radio\" for=\"item_name_1\"><input id=\"item_name_1\" name=\"item[name]\" type=\"radio\" value=\"1\" />One</label><label class=\"radio\" for=\"item_name_2\"><input id=\"item_name_2\" name=\"item[name]\" type=\"radio\" value=\"2\" />Two</label></div></div>"
       end


### PR DESCRIPTION
The id of the radio is sanitized but the `for` attribute of the label was not.
I copied the sanitize method from Rails: https://github.com/rails/rails/blob/f04dd33f330c96cdcf0b7a3728a9c2502db6a4c2/actionview/lib/action_view/helpers/tags/base.rb#L114-L116
